### PR TITLE
Bump kemitix-maven-tiles from 1.3.1 to 2.2.0

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -26,7 +26,7 @@ The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]
 ** Dependencies 
 
    - Bump assertj-core from 3.11.0 to 3.11.1 (#38)
-   - Bump kemitix-maven-tiles from 0.9.0 to 1.3.1 (#40)
+   - Bump kemitix-maven-tiles from 0.9.0 to 2.1.3 (#40)(#44)
    - Bump kemitix-parent from 5.1.1 to 5.2.0 (#39)
 
 * 0.7.0

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -26,7 +26,7 @@ The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]
 ** Dependencies 
 
    - Bump assertj-core from 3.11.0 to 3.11.1 (#38)
-   - Bump kemitix-maven-tiles from 0.9.0 to 2.1.3 (#40)(#44)
+   - Bump kemitix-maven-tiles from 0.9.0 to 2.2.0 (#40)(#44)
    - Bump kemitix-parent from 5.1.1 to 5.2.0 (#39)
 
 * 0.7.0

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <assertj.version>3.11.1</assertj.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
-        <kemitix-maven-tiles.version>1.3.1</kemitix-maven-tiles.version>
+        <kemitix-maven-tiles.version>2.1.3</kemitix-maven-tiles.version>
         <lombok.version>1.18.4</lombok.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <kemitix-checkstyle.version>4.1.1</kemitix-checkstyle.version>
         <junit.version>4.12</junit.version>
         <assertj.version>3.11.1</assertj.version>
-        <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
         <kemitix-maven-tiles.version>2.1.3</kemitix-maven-tiles.version>
         <lombok.version>1.18.4</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <junit.version>4.12</junit.version>
         <assertj.version>3.11.1</assertj.version>
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
-        <kemitix-maven-tiles.version>2.1.3</kemitix-maven-tiles.version>
+        <kemitix-maven-tiles.version>2.2.0</kemitix-maven-tiles.version>
         <lombok.version>1.18.4</lombok.version>
     </properties>
 

--- a/src/main/java/net/kemitix/conditional/FalseCondition.java
+++ b/src/main/java/net/kemitix/conditional/FalseCondition.java
@@ -59,7 +59,7 @@ final class FalseCondition implements Condition {
     }
 
     @Override
-    public void thenThrow(final Supplier<Exception> exceptionSupplier) throws Exception {
+    public void thenThrow(final Supplier<Exception> exceptionSupplier) {
         // do nothing
     }
 

--- a/src/main/java/net/kemitix/conditional/TrueCondition.java
+++ b/src/main/java/net/kemitix/conditional/TrueCondition.java
@@ -65,12 +65,12 @@ final class TrueCondition implements Condition {
     }
 
     @Override
-    public void otherwiseThrow(final Exception exception) throws Exception {
+    public void otherwiseThrow(final Exception exception) {
         // do nothing
     }
 
     @Override
-    public void otherwiseThrow(final Supplier<Exception> exceptionSupplier) throws Exception {
+    public void otherwiseThrow(final Supplier<Exception> exceptionSupplier) {
         // do nothing
     }
 


### PR DESCRIPTION
Remove unused throws Exception to comply with new spotbugs rules.